### PR TITLE
Commenting out set_library_file

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ import sys, os, importlib.util
 from typing import List
 from formalCheckInterface import FormalCheckInterface
 from alerts import Alert
-clang.cindex.Config.set_library_file('C:/Program Files/LLVM/bin/libclang.dll')
+# clang.cindex.Config.set_library_file('C:/Program Files/LLVM/bin/libclang.dll')
 
 # Relative directory that contains our check files.
 checks_dir = '../checks'


### PR DESCRIPTION
This line is optional, for people who run into the problem of libclang not knowing where libclang.dll is. It shouldn't be uncommented on main. My bad.