### PR TITLE
Removed arg when parsing translation unit

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,7 +28,7 @@ def main():
     # Gets clang to start parsing the file, and generate
     # a translation unit with an Abstract Syntax Tree.
     idx = clang.cindex.Index.create()
-    tu = idx.parse(s, args=['-std=c++11'])
+    tu = idx.parse(s)
 
     # Import all of our checks!
     try:

--- a/src/test.py
+++ b/src/test.py
@@ -65,7 +65,7 @@ def run_check_on_file(check_path: str, file_path: str = None) -> List[Alert]:
 
     # Make a Translation Unit
     idx = clang.cindex.Index.create()
-    tu = idx.parse(abs_file_path, args=['-std=c++11'])
+    tu = idx.parse(abs_file_path)
 
     # Traverse the AST of the TU, run the check on all cursors,
     # and return all alerts.


### PR DESCRIPTION
Removed an outdated arg in the main.py and test.py files when parsing the index for a translation unit. The outdated arg was causing some lines of code to be completely skipped over.

The arg was on line 31 in main.py, and line 68 in test.py