### PR TITLE
Removed faulty TypeKindObserver which is no longer needed

### DIFF
--- a/src/observer.py
+++ b/src/observer.py
@@ -73,34 +73,6 @@ class cursorKindObserver(Observer):
                 self.kindList.append(currentNode)
 
 
-class cursorTypeKindObserver(Observer):
-    def __init__(self, typeKindToDetect: clang.cindex.TypeKind):
-        """Initialiser
-        Initialises three members,
-            self.typeKindToDetect(clang.cindex.TypeKind)
-            self.typeKindList(list)
-            self.output(str)
-
-        Args:
-            typeKindToDetect (str): The clang.cindex.TypeKind
-        """
-        self.typeKindToDetect = typeKindToDetect
-        self.typeKindList = []
-        self.output = ""
-
-
-    def update(self, currentNode):
-        """Updates the observer with the currentNode
-
-        Args:
-            currentNode (clang.cindex.Cursor): The node to update with
-        """
-        self.typeKindList.append(currentNode)
-        if currentNode.type.kind == self.typeKindToDetect:
-            self.output += f"Detected {currentNode.type.spelling}: '{currentNode.displayname}' at {currentNode.location}\n"
-            self.typeKindList.append(currentNode)
-
-
 # Gráinne Ready
 # Subject class, has a list of observers which it notifies about events/state changes
 class EventSource():

--- a/src/test.py
+++ b/src/test.py
@@ -46,12 +46,11 @@ def test_observers():
     declared_variable_observer = cursorKindObserver(clang.cindex.CursorKind.FIELD_DECL)
     class_observer = cursorKindObserver(clang.cindex.CursorKind.CLASS_DECL)
     function_observer = cursorKindObserver(clang.cindex.CursorKind.CXX_METHOD)
-    record_observer = cursorTypeKindObserver(clang.cindex.TypeKind.RECORD)
     
     assert(eventSrc.observers) == []
-    eventSrc.addMultipleObservers([mutex_observer, lock_guard_observer, declared_variable_observer, class_observer, record_observer])
+    eventSrc.addMultipleObservers([mutex_observer, lock_guard_observer, declared_variable_observer, class_observer])
     eventSrc.addObserver(function_observer)
-    assert(eventSrc.observers) == [mutex_observer, lock_guard_observer, declared_variable_observer, class_observer, record_observer, function_observer]
+    assert(eventSrc.observers) == [mutex_observer, lock_guard_observer, declared_variable_observer, class_observer, function_observer]
 
     eventSrc2.addMultipleObservers([mutex_observer, lock_guard_observer, class_observer, function_observer])
     eventSrc2.removeMultipleObservers([mutex_observer, lock_guard_observer, class_observer])
@@ -68,17 +67,12 @@ Detected a 'std::lock_guard<std::mutex>' Lockguard's Name: 'lock_guard' at <Sour
 Detected std::string: 'mState' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 36, column 17>
 Detected std::mutex: 'mDataAccess' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 37, column 16>
 Detected MyClass: 'MyClass' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 5, column 7>
-Detected MyClass: 'MyClass' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 5, column 7>
-Detected std::mutex: 'class std::mutex' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 17, column 26>
-Detected const std::basic_string<char>: 'mState' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 19, column 12>
-Detected std::mutex: 'class std::mutex' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 24, column 26>
-Detected std::basic_string<char>: 'operator=' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 26, column 5>\nDetected std::mutex: 'class std::mutex' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 37, column 10>
 Detected std::string (): 'getState()' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 15, column 13>
 Detected void (const std::string &): 'updateState(const std::string &)' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 22, column 6>
 Detected void (): 'logState()' at <SourceLocation file '../cpp_tests/member_locked_in_some_methods/error_in_method_scope.cpp', line 29, column 6>
 """
 
-    output_str = f"{mutex_observer.output}{lock_guard_observer.output}{declared_variable_observer.output}{class_observer.output}{record_observer.output}{function_observer.output}"
+    output_str = f"{mutex_observer.output}{lock_guard_observer.output}{declared_variable_observer.output}{class_observer.output}{function_observer.output}"
     assert(output_str) == correct_output
 
 


### PR DESCRIPTION
TypeKindObserver was causing issues in github actions but working locally on some branches. It is not used in the antipatterns anymore, so it can be completely removed instead of unnecessary bug-fixing.