### PR TITLE
Fixed joinable traverse method

### DIFF
--- a/Checks/join_without_seeing_its_joinable.py
+++ b/Checks/join_without_seeing_its_joinable.py
@@ -30,7 +30,7 @@ class Check(FormalCheckInterface):
 						print("Found std::thread::joinable() function call at line {0}".format(node.location.line))
 
 
-			if joinDetected != joinableDetected:
+			if joinDetected > joinableDetected:
 				newAlert = Alert(cursor.translation_unit, cursor.extent,"Not all join functions are checked if thread is joinable")
 				if newAlert not in alerts:
 					alerts.append(newAlert)

--- a/Checks/join_without_seeing_its_joinable.py
+++ b/Checks/join_without_seeing_its_joinable.py
@@ -21,12 +21,13 @@ class Check(FormalCheckInterface):
 			joinableDetected = 0
 
 			for node in  cursor.translation_unit.cursor.walk_preorder():
-				if node.kind == clang.cindex.CursorKind.CALL_EXPR and node.spelling == "join" and node.type.spelling == "void": 
-					joinDetected += 1
-					#print("Found std::thread::join() function call at line {0}".format(node.location.line))
-				elif (node.kind == clang.cindex.CursorKind.CALL_EXPR and node.spelling == "joinable" and node.type.spelling == "bool"):
-					joinableDetected += 1
-					#print("Found std::thread::joinable() function call at line {0}".format(node.location.line))
+				if str(node.translation_unit.spelling) == str(node.location.file):
+					if node.kind == clang.cindex.CursorKind.CALL_EXPR and node.spelling == "join" and node.type.spelling == "void": 
+						joinDetected += 1
+						print("Found std::thread::join() function call at line {0}".format(node.location.line))
+					elif (node.kind == clang.cindex.CursorKind.CALL_EXPR and node.spelling == "joinable" and node.type.spelling == "bool"):
+						joinableDetected += 1
+						print("Found std::thread::joinable() function call at line {0}".format(node.location.line))
 
 
 			if joinDetected != joinableDetected:


### PR DESCRIPTION
This check has its own traversal at the start, but it didn't exclude cursors outside of the file we're running. I've fixed it so that it will exclude cursors outside of the file we're running. That way, we're only running checks on whats in the file we're testing.